### PR TITLE
Version 0.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.tfstate*
+terradata/.monitor
+monitor.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.6.0
+  - 1.6.1
   - tip
 
 os:

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -215,6 +215,7 @@ func startMonitor() {
 
 	for {
 		if !isTerrafarmActive() {
+			log.Info("Farm destroyed manually")
 			os.Exit(0)
 		}
 
@@ -431,11 +432,14 @@ func destroyCommand(prefs *Prefs) {
 	}
 
 	if !arg.GetB(ARG_FORCE) {
+		fmtc.NewLine()
+
 		if !terminal.ReadAnswer("Destroy farm? (y/N)", "n") {
-			fmtc.NewLine()
 			return
 		}
 	}
+
+	fmtutil.Separator(false)
 
 	vars, err := prefsToArgs(prefs)
 
@@ -443,8 +447,6 @@ func destroyCommand(prefs *Prefs) {
 		fmtc.Printf("{r}Can't parse prefs: %v{!}\n", err)
 		os.Exit(1)
 	}
-
-	fmtutil.Separator(false)
 
 	vars = append(vars, "-force")
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -353,7 +353,7 @@ func statusCommand(prefs *Prefs) {
 	case prefs.TTL > 120:
 		fmtc.Printf("  {*}%-16s{!} {y}%s{!}\n", "TTL:", timeutil.PrettyDuration(prefs.TTL*60))
 	default:
-		fmtc.Printf("  {*}%-16s{!} %s\n", "TTL:", timeutil.PrettyDuration(prefs.TTL*60))
+		fmtc.Printf("  {*}%-16s{!} {g}%s{!}\n", "TTL:", timeutil.PrettyDuration(prefs.TTL*60))
 	}
 
 	if regionValid {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -338,11 +338,18 @@ func createCommand(prefs *Prefs) {
 
 // statusCommand is status command handler
 func statusCommand(prefs *Prefs) {
+	fingerprint, _ := getFingerprint(prefs.Key + ".pub")
+
+	tokenValid := do.IsValidToken(prefs.Token)
+	fingerprintValid := do.IsFingerprintValid(prefs.Token, fingerprint)
+	regionValid := do.IsRegionValid(prefs.Token, prefs.Region)
+	sizeValid := do.IsSizeValid(prefs.Token, prefs.NodeSize)
+
 	fmtutil.Separator(false, "TERRAFARM")
 
 	fmtc.Printf("  {*}%-16s{!} %s", "Token:", getMaskedToken(prefs.Token))
 
-	if do.IsValidToken(prefs.Token) {
+	if tokenValid {
 		fmtc.Printf(" {g}✔{!}\n")
 	} else {
 		fmtc.Printf(" {r}✘{!}\n")
@@ -351,11 +358,9 @@ func statusCommand(prefs *Prefs) {
 	fmtc.Printf("  {*}%-16s{!} %s\n", "Private Key:", prefs.Key)
 	fmtc.Printf("  {*}%-16s{!} %s\n", "Public Key:", prefs.Key+".pub")
 
-	fingerprint, _ := getFingerprint(prefs.Key + ".pub")
-
 	fmtc.Printf("  {*}%-16s{!} %s", "Fingerprint:", fingerprint)
 
-	if do.IsFingerprintValid(prefs.Token, fingerprint) {
+	if fingerprintValid {
 		fmtc.Printf(" {g}✔{!}\n")
 	} else {
 		fmtc.Printf(" {r}✘{!}\n")
@@ -374,7 +379,7 @@ func statusCommand(prefs *Prefs) {
 
 	fmtc.Printf("  {*}%-16s{!} %s", "Region:", prefs.Region)
 
-	if do.IsRegionValid(prefs.Token, prefs.Region) {
+	if regionValid {
 		fmtc.Printf(" {g}✔{!}\n")
 	} else {
 		fmtc.Printf(" {r}✘{!}\n")
@@ -382,7 +387,7 @@ func statusCommand(prefs *Prefs) {
 
 	fmtc.Printf("  {*}%-16s{!} %s", "Node size:", prefs.NodeSize)
 
-	if do.IsSizeValid(prefs.Token, prefs.NodeSize) {
+	if sizeValid {
 		fmtc.Printf(" {g}✔{!}\n")
 	} else {
 		fmtc.Printf(" {r}✘{!}\n")

--- a/cli/prefs.go
+++ b/cli/prefs.go
@@ -37,7 +37,10 @@ type Prefs struct {
 // findAndReadPrefs read prefs from file and command-line arguments
 func findAndReadPrefs() *Prefs {
 	prefs := &Prefs{
+		Region:   "fra1",
+		NodeSize: "16gb",
 		TTL:      240,
+		User:     "builder",
 		Password: crypto.GenPassword(18, crypto.STRENGTH_MEDIUM),
 	}
 
@@ -187,6 +190,21 @@ func validatePrefs(prefs *Prefs) {
 
 	if prefs.Token == "" {
 		fmtc.Println("{r}Property token must be set{!}")
+		hasErrors = true
+	}
+
+	if prefs.Region == "" {
+		fmtc.Println("{r}Property region must be set{!}")
+		hasErrors = true
+	}
+
+	if prefs.NodeSize == "" {
+		fmtc.Println("{r}Property node-size must be set{!}")
+		hasErrors = true
+	}
+
+	if prefs.User == "" {
+		fmtc.Println("{r}Property user must be set{!}")
 		hasErrors = true
 	}
 

--- a/do/do.go
+++ b/do/do.go
@@ -1,0 +1,157 @@
+// Package do provides simple methods for checking DO preferencies
+package do
+
+// ////////////////////////////////////////////////////////////////////////////////// //
+//                                                                                    //
+//                     Copyright (c) 2009-2016 Essential Kaos                         //
+//      Essential Kaos Open Source License <http://essentialkaos.com/ekol?en>         //
+//                                                                                    //
+// ////////////////////////////////////////////////////////////////////////////////// //
+
+import (
+	"pkg.re/essentialkaos/ek.v1/req"
+)
+
+// ////////////////////////////////////////////////////////////////////////////////// //
+
+const DO_API = "https://api.digitalocean.com/v2"
+const USER_AGENT = "terrafarm"
+
+// ////////////////////////////////////////////////////////////////////////////////// //
+
+type Account struct {
+	Status string `json:"status"`
+}
+
+type AccountInfo struct {
+	Account *Account `json:"account"`
+}
+
+type KeysInfo struct {
+	Keys []*Key `json:"ssh_keys"`
+}
+
+type Key struct {
+	Fingerprint string `json:"fingerprint"`
+}
+
+type RegionsInfo struct {
+	Regions []*Region `json:"regions"`
+}
+
+type Region struct {
+	Slug string `json:"slug"`
+}
+
+type SizesInfo struct {
+	Sizes []*Region `json:"sizes"`
+}
+
+type Size struct {
+	Slug string `json:"slug"`
+}
+
+// ////////////////////////////////////////////////////////////////////////////////// //
+
+func IsValidToken(token string) bool {
+	resp, err := doAPIRequest(token, "/account")
+
+	if err != nil {
+		return false
+	}
+
+	accountInfo := &AccountInfo{}
+
+	err = resp.JSON(accountInfo)
+
+	if err != nil {
+		return false
+	}
+
+	return accountInfo.Account.Status == "active"
+}
+
+func IsFingerprintValid(token, fingerprint string) bool {
+	resp, err := doAPIRequest(token, "/account/keys")
+
+	if err != nil {
+		return false
+	}
+
+	keysInfo := &KeysInfo{}
+
+	err = resp.JSON(keysInfo)
+
+	if err != nil {
+		return false
+	}
+
+	for _, key := range keysInfo.Keys {
+		if key.Fingerprint == fingerprint {
+			return true
+		}
+	}
+
+	return false
+}
+
+func IsRegionValid(token, slug string) bool {
+	resp, err := doAPIRequest(token, "/regions")
+
+	if err != nil {
+		return false
+	}
+
+	regionsInfo := &RegionsInfo{}
+
+	err = resp.JSON(regionsInfo)
+
+	if err != nil {
+		return false
+	}
+
+	for _, region := range regionsInfo.Regions {
+		if region.Slug == slug {
+			return true
+		}
+	}
+
+	return false
+}
+
+func IsSizeValid(token, slug string) bool {
+	resp, err := doAPIRequest(token, "/sizes")
+
+	if err != nil {
+		return false
+	}
+
+	sizesInfo := &SizesInfo{}
+
+	err = resp.JSON(sizesInfo)
+
+	if err != nil {
+		return false
+	}
+
+	for _, size := range sizesInfo.Sizes {
+		if size.Slug == slug {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ////////////////////////////////////////////////////////////////////////////////// //
+
+func doAPIRequest(token, url string) (*req.Response, error) {
+	return req.Request{
+		URL:         DO_API + url,
+		UserAgent:   USER_AGENT,
+		ContentType: "application/json",
+		Headers: map[string]string{
+			"Authorization": "Bearer " + token,
+		},
+	}.Get()
+}

--- a/readme.md
+++ b/readme.md
@@ -49,8 +49,7 @@ Commands:
 
   create      Create and run farm droplets on DigitalOcean
   destroy     Destroy farm droplets on DigitalOcean
-  show        Show info about droplets in farm
-  plan        Show execution plan
+  status      Show current Terrafarm preferencies and status
 
 Options:
 
@@ -61,26 +60,24 @@ Options:
   --region, -R region     DigitalOcean region
   --node-size, -N size    Droplet size on DigitalOcean
   --user, -U username     Build node user name
+  --force, -f             Force command execution
   --no-color, -nc         Disable colors in output
   --help, -h              Show this help message
   --version, -v           Show version
 
 Examples:
 
-  terrafarm plan
-  Show build plan
+  terrafarm create --node-size 8gb --ttl 3h
+  Create farm with redefined node size and TTL
 
-  terrafarm plan --node-size 8gb --ttl 3h
-  Show build plan with redefined node size and TTL
-
-  terrafarm create --ttl 45m
-  Run farm with 45 min TTL
+  terrafarm create --force
+  Forced farm creation (without prompt)
 
   terrafarm destroy
   Destory all farm nodes
 
-  terrafarm show
-  Show info about build nodes
+  terrafarm status
+  Show info about terrafarm
 
 ```
 

--- a/terradata/variables.tf
+++ b/terradata/variables.tf
@@ -15,9 +15,9 @@ variable token {
 }
 
 variable region {
-  default = "fra1"
+  default = ""
 }
 
 variable node_size {
-  default = "16gb"
+  default = ""
 }


### PR DESCRIPTION
* Checking token, fingerprint, node size and region values through Digital Ocean API
* Added logging for farm monitor
* Sorted node list export (i386, i686, x64)
* Prompt for `create`/`destroy` commands
* `-f/--force` argument support for forcing `create`/`destroy` command execution
* Added `status` command for viewing farm preferencies
* Removed `plan` and `status` commands