### PR TITLE
Version 0.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.tfstate*
-terradata/.monitor
+terradata/.monitor-state
+terradata/.farm-state
 monitor.log

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	APP  = "Terrafarm"
-	VER  = "0.4.0"
+	VER  = "0.5.0"
 	DESC = "Utility for working with terraform based rpmbuilder farm"
 )
 
@@ -567,7 +567,7 @@ func execTerraform(logOutput bool, command string, args []string) error {
 			if logOutput {
 				log.Info(s.Text())
 			} else {
-				fmtc.Printf("  %s\n", s.Text())
+				fmtc.Printf("  %s\n", getColoredCommandOutput(s.Text()))
 			}
 		}
 	}()
@@ -587,6 +587,26 @@ func execTerraform(logOutput bool, command string, args []string) error {
 	fsutil.Pop()
 
 	return nil
+}
+
+// getColoredCommandOutput return command output with colored remote-exec
+func getColoredCommandOutput(line string) string {
+	// Remove garbage from line
+	line = strings.Replace(line, "\x1b[0m\x1b[0m", "", -1)
+
+	switch {
+	case strings.Contains(line, "-x32 (remote-exec)"):
+		return fmtc.Sprintf("{c}%s{!}", line)
+
+	case strings.Contains(line, "-x48 (remote-exec)"):
+		return fmtc.Sprintf("{b}%s{!}", line)
+
+	case strings.Contains(line, "-x64 (remote-exec)"):
+		return fmtc.Sprintf("{m}%s{!}", line)
+
+	default:
+		return line
+	}
 }
 
 // isTerrafarmActive return true if terrafarm already active

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -76,6 +76,9 @@ const MONITOR_STATE_FILE = ".monitor"
 // MONITOR_LOG_FILE is name of monitor log file
 const MONITOR_LOG_FILE = "monitor.log"
 
+// DATA_ENV_VAR is name of environment variable with path to data directory
+const DATA_ENV_VAR = "TERRADATA"
+
 // ////////////////////////////////////////////////////////////////////////////////// //
 
 type MonitorState struct {
@@ -171,6 +174,13 @@ func checkEnv() {
 
 	if !fsutil.CheckPerms("DRW", srcDir) {
 		fmtc.Printf("{r}Source directory %s is not accessible{!}\n", srcDir)
+		os.Exit(1)
+	}
+
+	dataDir := getDataDir()
+
+	if !fsutil.CheckPerms("DRW", dataDir) {
+		fmtc.Printf("{r}Data directory %s is not accessible{!}\n", dataDir)
 		os.Exit(1)
 	}
 }
@@ -615,6 +625,10 @@ func isMonitorActive() bool {
 
 // getDataDir return path to directory with terraform data
 func getDataDir() string {
+	if envMap[DATA_ENV_VAR] != "" {
+		return envMap[DATA_ENV_VAR]
+	}
+
 	return path.Join(getSrcDir(), "terradata")
 }
 

--- a/do/do.go
+++ b/do/do.go
@@ -14,7 +14,10 @@ import (
 
 // ////////////////////////////////////////////////////////////////////////////////// //
 
+// DO_API is DO API url
 const DO_API = "https://api.digitalocean.com/v2"
+
+// USER_AGENT is user agent used for all requests
 const USER_AGENT = "terrafarm"
 
 // ////////////////////////////////////////////////////////////////////////////////// //
@@ -53,6 +56,7 @@ type Size struct {
 
 // ////////////////////////////////////////////////////////////////////////////////// //
 
+// IsValidToken return true if token valid and account is active
 func IsValidToken(token string) bool {
 	resp, err := doAPIRequest(token, "/account")
 
@@ -71,6 +75,8 @@ func IsValidToken(token string) bool {
 	return accountInfo.Account.Status == "active"
 }
 
+// IsFingerprintValid return tru if provate key with given fingerprint is
+// present in Digital Ocean account
 func IsFingerprintValid(token, fingerprint string) bool {
 	resp, err := doAPIRequest(token, "/account/keys")
 
@@ -95,6 +101,8 @@ func IsFingerprintValid(token, fingerprint string) bool {
 	return false
 }
 
+// IsRegionValid return true if region with given slug is present
+// on Digital Ocean
 func IsRegionValid(token, slug string) bool {
 	resp, err := doAPIRequest(token, "/regions")
 
@@ -119,6 +127,8 @@ func IsRegionValid(token, slug string) bool {
 	return false
 }
 
+// IsSizeValid return true if size with given slug is present
+// on Digital Ocean
 func IsSizeValid(token, slug string) bool {
 	resp, err := doAPIRequest(token, "/sizes")
 
@@ -145,6 +155,7 @@ func IsSizeValid(token, slug string) bool {
 
 // ////////////////////////////////////////////////////////////////////////////////// //
 
+// doAPIRequest execute request to DO API
 func doAPIRequest(token, url string) (*req.Response, error) {
 	return req.Request{
 		URL:         DO_API + url,

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-## TerraFarm
+## Terrafarm
 
 `terrafarm` is utility for working with terraform based rpmbuilder farm on [DigitalOcean](https://www.digitalocean.com).
 
@@ -42,11 +42,11 @@ Command-line arguments have higher priority and overwrite properties defined in 
 
 #### Debugging
 
-If you find an bug with TerraFarm, please include the detailed log. As a user, this information can help work around the problem and prepare fixes. 
+If you find an bug with Terrafarm, please include the detailed log. As a user, this information can help work around the problem and prepare fixes. 
 
-First of all, you should specify `-D` or `--debug` argument with TerraFarm to print the output of command which would be executed. It might be useful to know what exactly parameters would be passed to Terraform.
+First of all, you should specify `-D` or `--debug` argument with Terrafarm to print the output of command which would be executed. It might be useful to know what exactly parameters would be passed to Terraform.
 
-Also keep in mind that TerraFarm works with Terraform and you should know how to debug it. We recommend to use `DEBUG` or `TRACE` values to find possible problems with Terraform. This will cause detailed logs to appear on stderr. To persist logged output you can set `TF_LOG_PATH` to write the log to a specific file.
+Also keep in mind that Terrafarm works with Terraform and you should know how to debug it. We recommend to use `DEBUG` or `TRACE` values to find possible problems with Terraform. This will cause detailed logs to appear on stderr. To persist logged output you can set `TF_LOG_PATH` to write the log to a specific file.
 
 #### Usage
 

--- a/terradata/builder-c6-x32.tf
+++ b/terradata/builder-c6-x32.tf
@@ -32,7 +32,6 @@ resource "digitalocean_droplet" "builder-x32" {
       "echo 'Installing RPMBuilder Node package...'",
       "yum -y -q install rpmbuilder-node",
       "echo 'Starting node configuration...'",
-      "yum -y -q install yum-utils",
       "yum-config-manager --disable kaos-release &> /dev/null",
       "yum-config-manager --enable kaos-release-i386 &> /dev/null",
       "sed -i 's#builder:!!#builder:${var.auth}#' /etc/shadow",

--- a/terradata/builder-c6-x48.tf
+++ b/terradata/builder-c6-x48.tf
@@ -32,7 +32,6 @@ resource "digitalocean_droplet" "builder-x48" {
       "echo 'Installing RPMBuilder Node package...'",
       "yum -y -q install rpmbuilder-node",
       "echo 'Starting node configuration...'",
-      "yum -y -q install yum-utils",
       "yum-config-manager --disable kaos-release &> /dev/null",
       "yum-config-manager --enable kaos-release-i686 &> /dev/null",
       "sed -i 's#builder:!!#builder:${var.auth}#' /etc/shadow",

--- a/terradata/builder-c6-x64.tf
+++ b/terradata/builder-c6-x64.tf
@@ -32,7 +32,6 @@ resource "digitalocean_droplet" "builder-x64" {
       "echo 'Installing RPMBuilder Node package...'",
       "yum -y -q install rpmbuilder-node",
       "echo 'Starting node configuration...'",
-      "yum -y -q install yum-utils",
       "yum-config-manager --disable kaos-release &> /dev/null",
       "yum-config-manager --enable kaos-release-x64 &> /dev/null",
       "sed -i 's#builder:!!#builder:${var.auth}#' /etc/shadow",


### PR DESCRIPTION
* Implemented redefining path to directory with terraform data
* Different colors for each node `remote-exec` output
* `INT` and `TERM` signal interception in create and destroy commands
* Added argument `--no-validate`/`-nv` which disable prefs validation on DO
* With working farm `status` command shows preferencies used for farm