### PR TITLE
Version 0.8.0

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -549,7 +549,7 @@ func destroyCommand(prefs *Preferences) {
 
 	fmtutil.Separator(false)
 
-	os.Remove(getFarmStateFilePath())
+	deleteFarmStateFile()
 }
 
 // templatesCommand is templates command handler
@@ -822,6 +822,11 @@ func getTerraformStateFilePath() string {
 // getFarmStateFilePath return path to terrafarm state file
 func getFarmStateFilePath() string {
 	return path.Join(getDataDir(), FARM_STATE_FILE)
+}
+
+// deleteFarmStateFile remote farm state file
+func deleteFarmStateFile() error {
+	return os.Remove(getFarmStateFilePath())
 }
 
 // saveFarmState save farm state to file

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -305,7 +305,7 @@ func processCommand(cmd string, args []string) {
 	case CMD_TEMPLATES:
 		templatesCommand()
 	default:
-		fmtc.Printf("{r}Unknown command %s\n", cmd)
+		printError("Unknown command %s", cmd)
 		exit(1)
 	}
 
@@ -353,7 +353,7 @@ func createCommand(prefs *Preferences, args []string) {
 	err = execTerraform(false, "apply", vars)
 
 	if err != nil {
-		fmtc.Printf("{r}Error while executing terraform: %v\n{!}", err)
+		printError("Error while executing terraform: %v", err)
 		exit(1)
 	}
 
@@ -367,7 +367,7 @@ func createCommand(prefs *Preferences, args []string) {
 		err = exportNodeList(prefs)
 
 		if err != nil {
-			fmtc.Printf("{r}Error while exporting info: %v\n", err)
+			printError("Error while exporting info: %v", err)
 		} else {
 			fmtc.Printf("{g}Info about build nodes saved as %s{!}\n", prefs.Output)
 		}
@@ -388,7 +388,7 @@ func createCommand(prefs *Preferences, args []string) {
 
 		if err != nil {
 			fmtc.NewLine()
-			fmtc.Printf("{r}Error while starting monitoring process: %v\n", err)
+			printError("Error while starting monitoring process: %v", err)
 			exit(1)
 		}
 
@@ -618,7 +618,7 @@ func destroyCommand(prefs *Preferences) {
 	err = execTerraform(false, "destroy", vars)
 
 	if err != nil {
-		fmtc.Printf("{r}Error while executing terraform: %v\n{!}", err)
+		printError("Error while executing terraform: %v", err)
 		exit(1)
 	}
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -626,6 +626,7 @@ func saveState(prefs *Preferences) {
 	}
 
 	farmState.Preferences.Token = getCryptedToken(prefs.Token)
+	farmState.Preferences.Password = ""
 
 	err := saveFarmState(farmState)
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -575,11 +575,26 @@ func destroyCommand(prefs *Preferences) {
 		exit(1)
 	}
 
+	activeBuildNodesNum := len(GetActiveBuildNodes(prefs))
+
 	if !arg.GetB(ARG_FORCE) {
 		fmtc.NewLine()
 
-		if !terminal.ReadAnswer("Destroy farm? (y/N)", "n") {
-			return
+		if activeBuildNodesNum != 0 {
+			yes := terminal.ReadAnswer(
+				fmtc.Sprintf(
+					"Currently farm have %s. Do you REALLY want destroy farm? (y/N)",
+					fmtutil.Pluralize(activeBuildNodesNum, "active build process", "active build processes"),
+				), "N",
+			)
+
+			if !yes {
+				return
+			}
+		} else {
+			if !terminal.ReadAnswer("Destroy farm? (y/N)", "n") {
+				return
+			}
 		}
 	}
 

--- a/cli/monitor.go
+++ b/cli/monitor.go
@@ -54,7 +54,7 @@ func startMonitor() {
 	for {
 		if !isTerrafarmActive() {
 			log.Info("Farm destroyed manually")
-			deleteMonitorState()
+			deleteMonitorStateFile()
 			exit(0)
 		}
 
@@ -86,14 +86,14 @@ func startMonitor() {
 
 		fsutil.Pop()
 
-		os.Remove(getFarmStateFilePath())
+		deleteFarmStateFile()
 
 		break
 	}
 
 	log.Info("Farm successfully destroyed!")
 
-	deleteMonitorState()
+	deleteMonitorStateFile()
 
 	exit(0)
 }
@@ -108,13 +108,14 @@ func getMonitorStateFilePath() string {
 	return path.Join(getDataDir(), MONITOR_STATE_FILE)
 }
 
+// deleteMonitorStateFile remote monitor state file
+func deleteMonitorStateFile() error {
+	return os.Remove(getMonitorStateFilePath())
+}
+
 // saveMonitorState save monitor state to file
 func saveMonitorState(state *MonitorState) error {
 	return jsonutil.EncodeToFile(getMonitorStateFilePath(), state)
-}
-
-func deleteMonitorState() error {
-	return os.Remove(getMonitorStateFilePath())
 }
 
 // readMonitorDestroyDate read monitor state from file

--- a/cli/monitor.go
+++ b/cli/monitor.go
@@ -228,7 +228,7 @@ func isFarmMustBeDestroyed(destroyAfter, destroyNotLater time.Time) bool {
 		exit(1)
 	}
 
-	activeBuildNodes := GetActiveBuildNodes(farmState.Preferences)
+	activeBuildNodes := getActiveBuildNodesNames(farmState.Preferences)
 
 	if len(activeBuildNodes) == 0 {
 		return true

--- a/cli/monitor.go
+++ b/cli/monitor.go
@@ -1,0 +1,156 @@
+package cli
+
+// ////////////////////////////////////////////////////////////////////////////////// //
+//                                                                                    //
+//                     Copyright (c) 2009-2016 Essential Kaos                         //
+//      Essential Kaos Open Source License <http://essentialkaos.com/ekol?en>         //
+//                                                                                    //
+// ////////////////////////////////////////////////////////////////////////////////// //
+
+import (
+	"os"
+	"os/exec"
+	"time"
+
+	"pkg.re/essentialkaos/ek.v1/arg"
+	"pkg.re/essentialkaos/ek.v1/fmtc"
+	"pkg.re/essentialkaos/ek.v1/fsutil"
+	"pkg.re/essentialkaos/ek.v1/jsonutil"
+	"pkg.re/essentialkaos/ek.v1/log"
+	"pkg.re/essentialkaos/ek.v1/path"
+	"pkg.re/essentialkaos/ek.v1/timeutil"
+)
+
+// ////////////////////////////////////////////////////////////////////////////////// //
+
+// MonitorState contains monitor specific info
+type MonitorState struct {
+	Pid          int   `json:"pid"`
+	DestroyAfter int64 `json:"destroy_after"`
+}
+
+// ////////////////////////////////////////////////////////////////////////////////// //
+
+// startMonitor starts monitoring process
+func startMonitor() {
+	destroyAfter := time.Unix(int64(arg.GetI(ARG_MONITOR)), 0)
+	monitorPid := os.Getpid()
+
+	state := &MonitorState{
+		Pid:          monitorPid,
+		DestroyAfter: int64(arg.GetI(ARG_MONITOR)),
+	}
+
+	stateFile := getMonitorStateFilePath()
+
+	err := saveMonitorState(stateFile, state)
+
+	if err != nil {
+		exit(1)
+	}
+
+	log.Set(getMonitorLogFilePath(), 0644)
+	log.Aux(SEPARATOR)
+	log.Aux("Terrafarm %s monitor started", VER)
+	log.Info("Farm will be destroyed after %s", timeutil.Format(destroyAfter, "%Y/%m/%d %H:%M:%S"))
+
+	for {
+		if !isTerrafarmActive() {
+			log.Info("Farm destroyed manually")
+			os.Remove(stateFile)
+			exit(0)
+		}
+
+		time.Sleep(time.Minute)
+
+		if time.Now().Unix() <= destroyAfter.Unix() {
+			continue
+		}
+
+		log.Info("Starting farm destroying...")
+
+		prefs := findAndReadPreferences()
+		vars, err := prefsToArgs(prefs, "-no-color", "-force")
+
+		if err != nil {
+			continue
+		}
+
+		fsutil.Push(path.Join(getDataDir(), prefs.Template))
+
+		err = execTerraform(true, "destroy", vars)
+
+		if err != nil {
+			log.Error("Can't destroy farm - terrafarm return error: %v", err)
+			continue
+		}
+
+		fsutil.Pop()
+
+		os.Remove(getFarmStateFilePath())
+
+		break
+	}
+
+	log.Info("Farm successfully destroyed!")
+
+	os.Remove(stateFile)
+
+	exit(0)
+}
+
+// getMonitorLogFilePath return path to monitor log file
+func getMonitorLogFilePath() string {
+	return path.Join(getDataDir(), MONITOR_LOG_FILE)
+}
+
+// getMonitorStateFilePath return path to monitor state file
+func getMonitorStateFilePath() string {
+	return path.Join(getDataDir(), MONITOR_STATE_FILE)
+}
+
+// saveMonitorState save monitor state to file
+func saveMonitorState(file string, state *MonitorState) error {
+	return jsonutil.EncodeToFile(file, state)
+}
+
+// readMonitorDestroyDate read monitor state from file
+func readMonitorState(file string) (*MonitorState, error) {
+	state := &MonitorState{}
+
+	err := jsonutil.DecodeFile(file, state)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return state, nil
+}
+
+// runMonitor run monitoring process
+func runMonitor(ttl int64) error {
+	destroyTime := time.Now().Unix() + (ttl * 60)
+
+	cmd := exec.Command("terrafarm", "--monitor", fmtc.Sprintf("%d", destroyTime))
+
+	return cmd.Start()
+}
+
+// isMonitorActive return true is monitor process is active
+func isMonitorActive() bool {
+	stateFile := getMonitorStateFilePath()
+
+	if !fsutil.IsExist(stateFile) {
+		return false
+	}
+
+	state, err := readMonitorState(stateFile)
+
+	if err != nil {
+		return false
+	}
+
+	return fsutil.IsExist(path.Join("/proc", fmtc.Sprintf("%d", state.Pid)))
+}
+
+// ////////////////////////////////////////////////////////////////////////////////// //

--- a/cli/prefs.go
+++ b/cli/prefs.go
@@ -23,6 +23,7 @@ import (
 // Preferences contains farm preferences
 type Preferences struct {
 	TTL      int64
+	MaxWait  int64
 	Output   string
 	Token    string
 	Key      string
@@ -87,32 +88,39 @@ func applyPreferencesFromFile(prefs *Preferences, file string) {
 		propVal := strings.TrimSpace(strings.Join(propSlice[1:], ":"))
 
 		switch strings.ToLower(propName) {
-		case "ttl":
+		case PREFS_TTL:
 			prefs.TTL = timeutil.ParseDuration(propVal) / 60
 
 			if prefs.TTL == 0 {
 				printError("Can't parse ttl property in %s file", file)
 			}
 
-		case "output":
+		case PREFS_MAX_WAIT, "max_wait", "maxwait":
+			prefs.MaxWait = timeutil.ParseDuration(propVal) / 60
+
+			if prefs.MaxWait == 0 {
+				printError("Can't parse max-wait property in %s file", file)
+			}
+
+		case PREFS_OUTPUT:
 			prefs.Output = propVal
 
-		case "token":
+		case PREFS_TOKEN:
 			prefs.Token = propVal
 
-		case "key":
+		case PREFS_KEY:
 			prefs.Key = propVal
 
-		case "region":
+		case PREFS_REGION:
 			prefs.Region = propVal
 
-		case "node_size", "node-size":
+		case PREFS_NODE_SIZE, "node_size", "nodesize":
 			prefs.NodeSize = propVal
 
-		case "user":
+		case PREFS_USER:
 			prefs.User = propVal
 
-		case "template":
+		case PREFS_TEMPLATE:
 			prefs.Template = propVal
 
 		default:
@@ -128,6 +136,14 @@ func applyPreferencesFromArgs(prefs *Preferences) {
 
 		if prefs.TTL == 0 {
 			printError("Can't parse ttl property from command-line arguments")
+		}
+	}
+
+	if arg.Has(ARG_MAX_WAIT) {
+		prefs.MaxWait = timeutil.ParseDuration(arg.GetS(ARG_MAX_WAIT)) / 60
+
+		if prefs.MaxWait == 0 {
+			printError("Can't parse max-wait property from command-line arguments")
 		}
 	}
 
@@ -165,7 +181,15 @@ func applyPreferencesFromEnvironment(prefs *Preferences) {
 		prefs.TTL = timeutil.ParseDuration(envMap[EV_TTL]) / 60
 
 		if prefs.TTL == 0 {
-			printError("Can't parse ttl property from environment variables")
+			printError("Can't parse %s property from environment variables", EV_TTL)
+		}
+	}
+
+	if envMap[EV_MAX_WAIT] != "" {
+		prefs.MaxWait = timeutil.ParseDuration(envMap[EV_MAX_WAIT]) / 60
+
+		if prefs.MaxWait == 0 {
+			printError("Can't parse %s property from environment variables", EV_TTL)
 		}
 	}
 

--- a/cli/prefs.go
+++ b/cli/prefs.go
@@ -92,14 +92,14 @@ func applyPreferencesFromFile(prefs *Preferences, file string) {
 			prefs.TTL = timeutil.ParseDuration(propVal) / 60
 
 			if prefs.TTL == 0 {
-				printError("Can't parse ttl property in %s file", file)
+				printError("Incorrect ttl property in %s file", file)
 			}
 
 		case PREFS_MAX_WAIT, "max_wait", "maxwait":
 			prefs.MaxWait = timeutil.ParseDuration(propVal) / 60
 
 			if prefs.MaxWait == 0 {
-				printError("Can't parse max-wait property in %s file", file)
+				printError("Incorrect max-wait property in %s file", file)
 			}
 
 		case PREFS_OUTPUT:
@@ -135,7 +135,7 @@ func applyPreferencesFromArgs(prefs *Preferences) {
 		prefs.TTL = timeutil.ParseDuration(arg.GetS(ARG_TTL)) / 60
 
 		if prefs.TTL == 0 {
-			printError("Can't parse ttl property from command-line arguments")
+			printError("Incorrect ttl property in command-line arguments")
 		}
 	}
 
@@ -143,7 +143,7 @@ func applyPreferencesFromArgs(prefs *Preferences) {
 		prefs.MaxWait = timeutil.ParseDuration(arg.GetS(ARG_MAX_WAIT)) / 60
 
 		if prefs.MaxWait == 0 {
-			printError("Can't parse max-wait property from command-line arguments")
+			printError("Incorrect max-wait property in command-line arguments")
 		}
 	}
 
@@ -181,7 +181,7 @@ func applyPreferencesFromEnvironment(prefs *Preferences) {
 		prefs.TTL = timeutil.ParseDuration(envMap[EV_TTL]) / 60
 
 		if prefs.TTL == 0 {
-			printError("Can't parse %s property from environment variables", EV_TTL)
+			printError("Incorrect %s property in environment variables", EV_TTL)
 		}
 	}
 
@@ -189,7 +189,7 @@ func applyPreferencesFromEnvironment(prefs *Preferences) {
 		prefs.MaxWait = timeutil.ParseDuration(envMap[EV_MAX_WAIT]) / 60
 
 		if prefs.MaxWait == 0 {
-			printError("Can't parse %s property from environment variables", EV_TTL)
+			printError("Incorrect %s property in environment variables", EV_TTL)
 		}
 	}
 

--- a/cli/prefs.go
+++ b/cli/prefs.go
@@ -158,10 +158,6 @@ func applyPreferencesFromArgs(prefs *Preferences) {
 	if arg.Has(ARG_PASSWORD) {
 		prefs.Password = arg.GetS(ARG_PASSWORD)
 	}
-
-	if arg.Has(ARG_TEMPLATE) {
-		prefs.Template = arg.GetS(ARG_TEMPLATE)
-	}
 }
 
 func applyPreferencesFromEnvironment(prefs *Preferences) {
@@ -268,17 +264,17 @@ func validatePreferences(prefs *Preferences) {
 	templateDir := getDataDir() + "/" + prefs.Template
 
 	if !fsutil.IsExist(templateDir) {
-		printError("Directory with farm data %s is not exist", templateDir)
+		printError("Directory with template %s is not exist", prefs.Template)
 		hasErrors = true
 	} else {
 		if !fsutil.IsReadable(templateDir) {
-			printError("Directory with farm data %s is not readable", templateDir)
+			printError("Directory with template %s is not readable", prefs.Template)
 			hasErrors = true
 		}
 
 		if fsutil.IsDir(templateDir) {
 			if fsutil.IsEmptyDir(templateDir) {
-				printError("Directory with farm data %s is empty", templateDir)
+				printError("Directory with template %s is empty", prefs.Template)
 				hasErrors = true
 			}
 		} else {

--- a/cli/remote.go
+++ b/cli/remote.go
@@ -1,0 +1,90 @@
+package cli
+
+// ////////////////////////////////////////////////////////////////////////////////// //
+//                                                                                    //
+//                     Copyright (c) 2009-2016 Essential Kaos                         //
+//      Essential Kaos Open Source License <http://essentialkaos.com/ekol?en>         //
+//                                                                                    //
+// ////////////////////////////////////////////////////////////////////////////////// //
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strconv"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// ////////////////////////////////////////////////////////////////////////////////// //
+
+// GetActiveBuildNodes return list of nodes with active build process
+func GetActiveBuildNodes(prefs *Preferences, maxBuildTime int) []string {
+	keyData, err := ioutil.ReadFile(prefs.Key)
+
+	if err != nil {
+		fmt.Println(err.Error())
+		return []string{}
+	}
+
+	signer, err := ssh.ParsePrivateKey(keyData)
+
+	if err != nil {
+		fmt.Println(err.Error())
+		return []string{}
+	}
+
+	sshConfig := &ssh.ClientConfig{
+		User: "root",
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(signer),
+		},
+	}
+
+	var result []string
+
+	nodes, err := getNodeList(prefs)
+
+	if err != nil {
+		fmt.Println(err.Error())
+		return []string{}
+	}
+
+	for nodeName, nodeIP := range nodes {
+		client, err := ssh.Dial("tcp", nodeIP+":22", sshConfig)
+
+		if err != nil {
+			fmt.Println(err.Error())
+			continue
+		}
+
+		session, err := client.NewSession()
+
+		if err != nil {
+			fmt.Println(err.Error())
+			client.Close()
+			continue
+		}
+
+		output, err := session.Output(
+			fmt.Sprintf("stat -c '%%Y' /home/%s/.buildlock", prefs.User),
+		)
+
+		if err == nil {
+			if maxBuildTime > 0 {
+				buildStartTimestamp, _ := strconv.Atoi(string(output))
+
+				if buildStartTimestamp+maxBuildTime > int(time.Now().Unix()) {
+					result = append(result, nodeName)
+				}
+			} else {
+				result = append(result, nodeName)
+			}
+		}
+
+		session.Close()
+		client.Close()
+	}
+
+	return result
+}

--- a/cli/remote.go
+++ b/cli/remote.go
@@ -10,8 +10,6 @@ package cli
 import (
 	"fmt"
 	"io/ioutil"
-	"strconv"
-	"time"
 
 	"golang.org/x/crypto/ssh"
 )
@@ -19,7 +17,7 @@ import (
 // ////////////////////////////////////////////////////////////////////////////////// //
 
 // GetActiveBuildNodes return list of nodes with active build process
-func GetActiveBuildNodes(prefs *Preferences, maxBuildTime int) []string {
+func GetActiveBuildNodes(prefs *Preferences) []string {
 	keyData, err := ioutil.ReadFile(prefs.Key)
 
 	if err != nil {
@@ -66,20 +64,12 @@ func GetActiveBuildNodes(prefs *Preferences, maxBuildTime int) []string {
 			continue
 		}
 
-		output, err := session.Output(
+		_, err = session.Output(
 			fmt.Sprintf("stat -c '%%Y' /home/%s/.buildlock", prefs.User),
 		)
 
 		if err == nil {
-			if maxBuildTime > 0 {
-				buildStartTimestamp, _ := strconv.Atoi(string(output))
-
-				if buildStartTimestamp+maxBuildTime > int(time.Now().Unix()) {
-					result = append(result, nodeName)
-				}
-			} else {
-				result = append(result, nodeName)
-			}
+			result = append(result, nodeName)
 		}
 
 		session.Close()

--- a/cli/remote.go
+++ b/cli/remote.go
@@ -10,6 +10,7 @@ package cli
 import (
 	"fmt"
 	"io/ioutil"
+	"time"
 
 	"golang.org/x/crypto/ssh"
 )
@@ -37,6 +38,7 @@ func GetActiveBuildNodes(prefs *Preferences) []string {
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(signer),
 		},
+		Timeout: time.Second,
 	}
 
 	var result []string

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@
 
 #### Usage demo
 
-[![asciicast](https://essentialkaos.com/github/terrafarm-080.gif)](https://asciinema.org/a/44873)
+[![asciicast](https://essentialkaos.com/github/terrafarm-080-1.gif)](https://asciinema.org/a/47774)
 
 #### Installation
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ![terrafarm Logo](https://essentialkaos.com/github/terrafarm-v1.png)
 
-`terrafarm` is utility for working with [Terraform](https://www.terraform.io) based rpmbuilder farm on [DigitalOcean](https://www.digitalocean.com).
+`terrafarm` is utility for working with [Terraform](https://www.terraform.io) based [rpmbuilder](https://github.com/essentialkaos/rpmbuilder) farm on [DigitalOcean](https://www.digitalocean.com).
 
 * [Usage Demo](#usage-demo)
 * [Installation](#installation)

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ![terrafarm Logo](https://essentialkaos.com/github/terrafarm-v1.png)
 
-`terrafarm` is utility for working with terraform based rpmbuilder farm on [DigitalOcean](https://www.digitalocean.com).
+`terrafarm` is utility for working with [Terraform](https://www.terraform.io) based rpmbuilder farm on [DigitalOcean](https://www.digitalocean.com).
 
 * [Usage Demo](#usage-demo)
 * [Installation](#installation)
@@ -20,7 +20,7 @@
 
 #### Installation
 
-To build the terrafarm from scratch, make sure you have a working Go 1.5+ workspace ([instructions](https://golang.org/doc/install)), then:
+To build the terrafarm from scratch, make sure you have a working Go 1.5+ workspace ([instructions](https://golang.org/doc/install)) and latest version of [Terraform](https://www.terraform.io/downloads.html), then:
 
 ```
 go get github.com/essentialkaos/terrafarm

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@ You can define or redefine properties using next variables:
 
 * `TERRAFARM_DATA` - Path to directory with your own Terraform data
 * `TERRAFARM_TTL` - Max farm TTL (Time To Live)
+* `TERRAFARM_MAX_WAIT` - Max time which monitor will wait if farm have active build
 * `TERRAFARM_OUTPUT` - Path to output file with access credentials
 * `TERRAFARM_TEMPLATE` - Farm template name
 * `TERRAFARM_TOKEN` - DigitalOcean token
@@ -112,10 +113,12 @@ Commands:
   destroy                 Destroy farm droplets on DigitalOcean
   status                  Show current Terrafarm preferences and status
   templates               List all available farm templates
+  prolong ttl max-wait    Increase TTL or set max wait time
 
 Options:
 
-  --ttl, -t ttl              Max farm TTL (Time To Live)
+  --ttl, -t time             Max farm TTL (Time To Live)
+  --max-wait, -w time        Max time which monitor will wait if farm have active build
   --output, -o file          Path to output file with access credentials
   --token, -T token          DigitalOcean token
   --key, -K key-file         Path to private key
@@ -145,6 +148,9 @@ Examples:
 
   terrafarm status
   Show info about terrafarm
+
+  terrafarm prolong 1h 15m
+  Increase TTL on 1 hour and set max wait to 15 minutes
 
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-## Terrafarm
+![terrafarm Logo](https://essentialkaos.com/github/terrafarm-v1.png)
 
 `terrafarm` is utility for working with terraform based rpmbuilder farm on [DigitalOcean](https://www.digitalocean.com).
 

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ key: /home/user/.ssh/terra-farm
 output: /home/user/terrafarm-nodes.list
 region: ams3
 node-size: 8gb
-ttl: 240
+ttl: 2h
 ```
 
 Preferences file must be named as `.terrafarm` and placed in your `HOME` directory.
@@ -108,16 +108,15 @@ Usage: terrafarm <command> <options>
 
 Commands:
 
-  create        Create and run farm droplets on DigitalOcean
-  destroy       Destroy farm droplets on DigitalOcean
-  status        Show current Terrafarm preferences and status
-  templates     List all available farm templates
+  create template-name    Create and run farm droplets on DigitalOcean
+  destroy                 Destroy farm droplets on DigitalOcean
+  status                  Show current Terrafarm preferences and status
+  templates               List all available farm templates
 
 Options:
 
   --ttl, -t ttl              Max farm TTL (Time To Live)
   --output, -o file          Path to output file with access credentials
-  --template, -L name        Farm template name
   --token, -T token          DigitalOcean token
   --key, -K key-file         Path to private key
   --region, -R region        DigitalOcean region
@@ -137,6 +136,9 @@ Examples:
 
   terrafarm create --force
   Forced farm creation (without prompt)
+
+  terrafarm create c6-multiarch-fast
+  Create farm from template c6-multiarch-fast
 
   terrafarm destroy
   Destroy all farm nodes

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@
 
 #### Usage demo
 
-[![asciicast](https://asciinema.org/a/44873.png)](https://asciinema.org/a/44873)
+[![asciicast](https://essentialkaos.com/github/terrafarm-080.gif)](https://asciinema.org/a/44873)
 
 #### Installation
 

--- a/readme.md
+++ b/readme.md
@@ -14,11 +14,11 @@
 * [Contributing](#contributing)
 * [License](#license)
 
-#### Usage demo
+## Usage demo
 
 [![asciicast](https://essentialkaos.com/github/terrafarm-080-1.gif)](https://asciinema.org/a/47774)
 
-#### Installation
+## Installation
 
 To build the terrafarm from scratch, make sure you have a working Go 1.5+ workspace ([instructions](https://golang.org/doc/install)) and latest version of [Terraform](https://www.terraform.io/downloads.html), then:
 
@@ -32,7 +32,7 @@ If you want update terrafarm to latest stable release, do:
 go get -u github.com/essentialkaos/terrafarm
 ```
 
-#### Configuration
+## Configuration
 
 `terrafarm` have three ways for farm configuration — preferences file, environment variables and command-line arguments.
 
@@ -42,7 +42,7 @@ You can use all three ways simultaneously, but in this case `terrafarm` uses dif
 2. Environment variables
 3. Command-line arguments (_highest priority_)
 
-##### Preferences file
+### Preferences file
 
 Preferences file use next format:
 
@@ -64,7 +64,7 @@ ttl: 2h
 
 Preferences file must be named as `.terrafarm` and placed in your `HOME` directory.
 
-##### Environment variables
+### Environment variables
 
 _Environment variables overwrite properties defined in preferences file._
 
@@ -88,13 +88,13 @@ Example:
 TERRAFARM_DATA=/home/user/my-own-terraform-data TERRAFARM_TTL=1h terrafarm create
 ```
 
-##### Command-line arguments
+### Command-line arguments
 
 _Command-line arguments overwrite properties defined in preferences file and environment variables._
 
 All supported command-line arguments with usage examples can be found in [usage](#usage) section.
 
-#### Debugging
+## Debugging
 
 If you find an bug with Terrafarm, please include the detailed log. As a user, this information can help work around the problem and prepare fixes. 
 
@@ -102,7 +102,7 @@ First of all, you should specify `-D` or `--debug` argument with Terrafarm to pr
 
 Also keep in mind that Terrafarm works with Terraform and you should know how to debug it. We recommend to use `DEBUG` or `TRACE` values to find possible problems with Terraform. This will cause detailed logs to appear on stderr. To persist logged output you can set `TF_LOG_PATH` to write the log to a specific file.
 
-#### Usage
+## Usage
 
 ```
 Usage: terrafarm <command> <options>
@@ -154,17 +154,17 @@ Examples:
 
 ```
 
-#### Build Status
+## Build Status
 
 | Repository | Status |
 |------------|--------|
 | Stable | [![Build Status](https://travis-ci.org/essentialkaos/terrafarm.svg?branch=master)](https://travis-ci.org/essentialkaos/terrafarm) |
 | Unstable | [![Build Status](https://travis-ci.org/essentialkaos/terrafarm.svg?branch=develop)](https://travis-ci.org/essentialkaos/terrafarm) |
 
-#### Contributing
+## Contributing
 
 Before contributing to this project please read our [Contributing Guidelines](https://github.com/essentialkaos/contributing-guidelines#contributing-guidelines).
 
-#### License
+## License
 
 [EKOL](https://essentialkaos.com/ekol)


### PR DESCRIPTION
##### New Features:
* `TF-19` Defer destroying by monitor if farm have active builds :fire: 
* `TF-18` Showing number of active build processes in status command output :fire:
* `TF-17` Added command `prolong` for increasing TTL :fire:
* `TF-27` Showing access credentials if output file not provided

##### Improvements:
* `TF-16` Improved node info export
* `TF-21` Improved syntax of farm creation with custom template usage
* `TF-25` Improved monitor starting process
* `TF-22` Improved destroy command handling
* `TF-28` Improved terraform preogress output
* `TF-23` Improved build nodes status output
* Code refactoring

##### Bugfixes:
* `TF-24` Added one second timeout for ssh connection
* `TF-26` Build node password now always empty in farm state file :see_no_evil: